### PR TITLE
account_statement: Prevent the reconciliation of lines with a draft move when validating a statement

### DIFF
--- a/statement.py
+++ b/statement.py
@@ -143,7 +143,7 @@ class Statement(Workflow, ModelSQL, ModelView):
                     'invisible': Eval('state') != 'cancelled',
                     'depends': ['state'],
                     },
-                'validate_statement': {
+                'dummy_validate_method': {
                     'invisible': Eval('state') != 'draft',
                     'depends': ['state'],
                     },
@@ -465,6 +465,10 @@ class Statement(Workflow, ModelSQL, ModelView):
     @classmethod
     @ModelView.button
     @Workflow.transition('validated')
+    def dummy_validate_method(cls, statements):
+        return
+
+    @classmethod
     def validate_statement(cls, statements):
         pool = Pool()
         Line = pool.get('account.statement.line')
@@ -610,6 +614,7 @@ class Statement(Workflow, ModelSQL, ModelView):
         pool = Pool()
         Lang = pool.get('ir.lang')
         StatementLine = pool.get('account.statement.line')
+        cls.validate_statement(statements)
         for statement in statements:
             for origin in statement.origins:
                 if origin.pending_amount:

--- a/statement.py
+++ b/statement.py
@@ -132,10 +132,8 @@ class Statement(Workflow, ModelSQL, ModelView):
         super(Statement, cls).__setup__()
         cls._order[0] = ('id', 'DESC')
         cls._transitions |= set((
-                ('draft', 'validated'),
+                ('draft', 'posted'),
                 ('draft', 'cancelled'),
-                ('validated', 'posted'),
-                ('validated', 'cancelled'),
                 ('cancelled', 'draft'),
                 ))
         cls._buttons.update({
@@ -143,16 +141,12 @@ class Statement(Workflow, ModelSQL, ModelView):
                     'invisible': Eval('state') != 'cancelled',
                     'depends': ['state'],
                     },
-                'validate_statement': {
+                'post': {
                     'invisible': Eval('state') != 'draft',
                     'depends': ['state'],
                     },
-                'post': {
-                    'invisible': Eval('state') != 'validated',
-                    'depends': ['state'],
-                    },
                 'cancel': {
-                    'invisible': ~Eval('state').in_(['draft', 'validated']),
+                    'invisible': ~Eval('state').in_(['draft']),
                     'depends': ['state'],
                     },
                 'reconcile': {
@@ -463,8 +457,6 @@ class Statement(Workflow, ModelSQL, ModelView):
                     n=self.number_of_lines - number))
 
     @classmethod
-    @ModelView.button
-    @Workflow.transition('validated')
     def validate_statement(cls, statements):
         pool = Pool()
         Line = pool.get('account.statement.line')
@@ -610,6 +602,7 @@ class Statement(Workflow, ModelSQL, ModelView):
         pool = Pool()
         Lang = pool.get('ir.lang')
         StatementLine = pool.get('account.statement.line')
+        cls.validate_statement(statements)
         for statement in statements:
             for origin in statement.origins:
                 if origin.pending_amount:

--- a/statement.xml
+++ b/statement.xml
@@ -196,7 +196,7 @@ this repository contains the full copyright notices and license terms. -->
         </record>
 
         <record model="ir.model.button" id="statement_validate_button">
-            <field name="name">validate_statement</field>
+            <field name="name">dummy_validate_method</field>
             <field name="string">Validate</field>
             <field name="model"
                 search="[('model', '=', 'account.statement')]"/>

--- a/tests/scenario_account_statement.rst
+++ b/tests/scenario_account_statement.rst
@@ -346,20 +346,20 @@ Testing the use of an invoice in multiple statements::
     >>> statement_line.related_to = customer_invoice4
     >>> statement2.save()
 
+    >>> Model.get('res.user.warning')(user=config.user,
+    ...     name=str(statement2.lines[0].id), always=True).save()
+
     >>> statement1.click('dummy_validate_method')
-    >>> statement1.click('post') # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    StatementValidateWarning: ...
+    >>> statement1.click('post')
     >>> statement1.state
-    'validated'
+    'posted'
 
     >>> statement1.reload()
     >>> bool(statement1.lines[0].related_to)
     True
     >>> statement2.reload()
     >>> bool(statement2.lines[0].related_to)
-    True
+    False
 
 Testing balance validation::
 
@@ -380,6 +380,11 @@ Testing balance validation::
     >>> line.account = receivable
     >>> line.party = customer
     >>> statement.click('dummy_validate_method')
+    >>> statement.click('post')  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    StatementValidateError: ...
+
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
     >>> second_line.amount = Decimal('40.00')
@@ -406,6 +411,10 @@ Testing amount validation::
     >>> line.account = receivable
     >>> line.party = customer
     >>> statement.click('dummy_validate_method')
+    >>> statement.click('post') # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    StatementValidateError: ...
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
@@ -433,6 +442,11 @@ Test number of lines validation::
     >>> line.account = receivable
     >>> line.party = customer
     >>> statement.click('dummy_validate_method')
+    >>> statement.click('post')   # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    StatementValidateError: ...
+
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today

--- a/tests/scenario_account_statement.rst
+++ b/tests/scenario_account_statement.rst
@@ -194,14 +194,17 @@ Paid 50 to supplier::
 
 Validate statement::
 
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
     >>> statement.state
     'validated'
 
 Try posting a move::
 
     >>> statement_line = statement.lines[0]
-    >>> statement_line.move.click('post')  # doctest: +IGNORE_EXCEPTION_DETAIL
+
+We do not create moves in validate anymore::
+
+statement_line.move.click('post')  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     trytond.modules.account.exceptions.PostError: ...
@@ -219,7 +222,7 @@ Reset to draft, validate and post statement::
     >>> statement.click('draft')
     >>> statement.state
     'draft'
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
     >>> statement.state
     'validated'
     >>> statement.click('post')
@@ -354,14 +357,7 @@ Testing the use of an invoice in multiple statements::
     >>> statement_line.related_to = customer_invoice4
     >>> statement2.save()
 
-    >>> statement1.click('validate_statement') # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    StatementValidateWarning: ...
-    >>> statement2.reload()
-    >>> Model.get('res.user.warning')(user=config.user,
-    ...     name=str(statement2.lines[0].id), always=True).save()
-    >>> statement1.click('validate_statement')
+    >>> statement1.click('dummy_validate_method')
     >>> statement1.state
     'validated'
 
@@ -370,7 +366,7 @@ Testing the use of an invoice in multiple statements::
     True
     >>> statement2.reload()
     >>> bool(statement2.lines[0].related_to)
-    False
+    True
 
 Testing balance validation::
 
@@ -390,17 +386,14 @@ Testing balance validation::
     >>> line.amount = Decimal('60.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('validate_statement')  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    StatementValidateError: ...
+    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
     >>> second_line.amount = Decimal('40.00')
     >>> second_line.account = receivable
     >>> second_line.party = customer
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 
 Testing amount validation::
 
@@ -419,17 +412,14 @@ Testing amount validation::
     >>> line.amount = Decimal('50.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('validate_statement')  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    StatementValidateError: ...
+    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
     >>> second_line.amount = Decimal('30.00')
     >>> second_line.account = receivable
     >>> second_line.party = customer
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 
 Test number of lines validation::
 
@@ -448,21 +438,18 @@ Test number of lines validation::
     >>> line.amount = Decimal('50.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('validate_statement')  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    StatementValidateError: ...
+    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
     >>> second_line.amount = Decimal('10.00')
     >>> second_line.account = receivable
     >>> second_line.party = customer
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 
 Validate empty statement::
 
     >>> statement = Statement(name='empty', journal=statement_journal)
     >>> statement.end_balance = statement.start_balance
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 

--- a/tests/scenario_account_statement.rst
+++ b/tests/scenario_account_statement.rst
@@ -198,17 +198,6 @@ Validate statement::
     >>> statement.state
     'validated'
 
-Try posting a move::
-
-    >>> statement_line = statement.lines[0]
-
-We do not create moves in validate anymore::
-
-statement_line.move.click('post')  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-        ...
-    trytond.modules.account.exceptions.PostError: ...
-
 Cancel statement::
 
     >>> statement.click('cancel')
@@ -358,6 +347,10 @@ Testing the use of an invoice in multiple statements::
     >>> statement2.save()
 
     >>> statement1.click('dummy_validate_method')
+    >>> statement1.click('post') # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    StatementValidateWarning: ...
     >>> statement1.state
     'validated'
 
@@ -386,14 +379,14 @@ Testing balance validation::
     >>> line.amount = Decimal('60.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
-
+    >>> statement.click('dummy_validate_method')
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
     >>> second_line.amount = Decimal('40.00')
     >>> second_line.account = receivable
     >>> second_line.party = customer
     >>> statement.click('dummy_validate_method')
+    >>> statement.click('post')
 
 Testing amount validation::
 
@@ -412,7 +405,7 @@ Testing amount validation::
     >>> line.amount = Decimal('50.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> statement.click('dummy_validate_method')
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today
@@ -420,6 +413,7 @@ Testing amount validation::
     >>> second_line.account = receivable
     >>> second_line.party = customer
     >>> statement.click('dummy_validate_method')
+    >>> statement.click('post')
 
 Test number of lines validation::
 
@@ -438,7 +432,7 @@ Test number of lines validation::
     >>> line.amount = Decimal('50.00')
     >>> line.account = receivable
     >>> line.party = customer
-    >>> statement.click('dummy_validate_method')  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> statement.click('dummy_validate_method')
 
     >>> second_line = statement.lines.new()
     >>> second_line.date = today

--- a/tests/scenario_statement_origin.rst
+++ b/tests/scenario_statement_origin.rst
@@ -65,7 +65,7 @@ Create a statement with origins::
     >>> origin.date = today
     >>> origin.amount = Decimal('50.00')
     >>> origin.party = customer
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 
 Statement can not be posted until all origins are finished::
 

--- a/tests/scenario_statement_origin_invoices.rst
+++ b/tests/scenario_statement_origin_invoices.rst
@@ -89,7 +89,7 @@ Create a statement with origins::
     >>> origin = statement.origins.new()
     >>> origin.date = today
     >>> origin.amount = Decimal('180.00')
-    >>> statement.click('validate_statement')
+    >>> statement.click('dummy_validate_method')
 
 Pending amount is used to fill all invoices::
 

--- a/view/statement_form.xml
+++ b/view/statement_form.xml
@@ -42,7 +42,7 @@ this repository contains the full copyright notices and license terms. -->
     <group col="-1" colspan="2" id="buttons">
         <button name="cancel" icon="tryton-cancel"/>
         <button name="draft" icon="tryton-undo"/>
-        <button name="validate_statement" icon="tryton-forward"/>
+        <button name="dummy_validate_method" icon="tryton-forward"/>
         <button name="reconcile" icon="tryton-search"/>
         <button name="post" icon="tryton-ok"/>
     </group>

--- a/view/statement_form.xml
+++ b/view/statement_form.xml
@@ -42,7 +42,6 @@ this repository contains the full copyright notices and license terms. -->
     <group col="-1" colspan="2" id="buttons">
         <button name="cancel" icon="tryton-cancel"/>
         <button name="draft" icon="tryton-undo"/>
-        <button name="validate_statement" icon="tryton-forward"/>
         <button name="reconcile" icon="tryton-search"/>
         <button name="post" icon="tryton-ok"/>
     </group>

--- a/view/statement_form.xml
+++ b/view/statement_form.xml
@@ -42,6 +42,7 @@ this repository contains the full copyright notices and license terms. -->
     <group col="-1" colspan="2" id="buttons">
         <button name="cancel" icon="tryton-cancel"/>
         <button name="draft" icon="tryton-undo"/>
+        <button name="validate_statement" icon="tryton-forward"/>
         <button name="reconcile" icon="tryton-search"/>
         <button name="post" icon="tryton-ok"/>
     </group>


### PR DESCRIPTION
Fix #PJAZZ-856